### PR TITLE
Add assertions in Parser to validate command input

### DIFF
--- a/src/main/java/dino/Parser.java
+++ b/src/main/java/dino/Parser.java
@@ -11,7 +11,9 @@ public class Parser {
      * @throws DukeException if the command is invalid or missing required information
      */
     public static Command parse(String command) throws DukeException {
+        assert command != null : "Command cannot be empty";
         String[] parts = command.trim().split(" ", 2);
+        assert parts.length >= 1 : "Command must have at least one word";
         String commandType = parts[0];
         String commandDetail = parts.length > 1 ? parts[1] : "";
 


### PR DESCRIPTION
Add assertions to ensure that command is not null and that it contains at least one word before parsing. This documents assumptions about input state and makes potential logic errors easier to catch.

Keep DukeException for handling invalid user input, since assertions are intended only for internal consistency checks.